### PR TITLE
Fix bug with add_days() by moving default day / month values to 1 from 0

### DIFF
--- a/addons/datetime/datetime.gd
+++ b/addons/datetime/datetime.gd
@@ -36,13 +36,13 @@ var minute := 0
 var hour := 0
 
 # The day in the current month
-var day := 0
+var day := 1
 
 # The day in the current year
 var julian := 0
 
 # The month in the current year
-var month := 0
+var month := 1
 
 # The current year
 var year := 0


### PR DESCRIPTION
Current new instantiation sets all time lengths to 0. This is fine for years, hours, minutes, seconds, but doesn't follow spec for month and day. A simple way to test this being broken is to instantiate a new datetime, then use .add_days(7) which will fail because of the following :

![image](https://github.com/verillious/godot-datetime/assets/5817861/00146ac5-e5f3-4a2f-bfbb-72a15de9f3a2)

The function is fine, the instantiation is wrong, IMO. Playing around with online tools it looks like 0 is invalid for month and day, so let's instantiate them at 1 instead. 

https://epochunixtime.com/